### PR TITLE
Allow the device parameters box to be resized

### DIFF
--- a/app/assets/stylesheets/devices.css.scss
+++ b/app/assets/stylesheets/devices.css.scss
@@ -43,6 +43,8 @@
 
   ul.list {
     height: 200px;
+    min-height: 200px;
+    resize: vertical;
     overflow-y: scroll;
 
     li {


### PR DESCRIPTION
Fox me, sometimes the 200px max height of the device parameters block is to small. I've set the min-height to 200, and allowed the box to be resized.
