### PR TITLE
Create firmware helper link on the device page

### DIFF
--- a/app/views/devices/show.html.erb
+++ b/app/views/devices/show.html.erb
@@ -137,7 +137,7 @@ $(function() {
 <% if can?(:update, 'devices/reboot') %>
 <div><a id="reboot" href="#" onclick="reboot();return false;">Reboot</a></div>
 <% end %>
-<% if can?(:update, 'devices/fectory_reset') %>
+<% if can?(:update, 'devices/factory_reset') %>
 <div><a id="factory-reset" href="#" onclick="factoryReset();return false;">Factory reset</a></div>
 <% end %>
 <% if can?(:update, 'devices/download') %>
@@ -149,11 +149,16 @@ $(function() {
     <% end %>
   </div>
 </div>
-</p>
 <% end %>
+<% if can?(:create, 'files') %>
+
+<div><%= link_to 'Add Firmware', {controller: 'files', action: 'new', params: {oui: @device['summary.oui'].html_safe, product_class: @device['summary.productClass'].html_safe, version: @device['summary.softwareVersion']['_value'].html_safe }}  %></div>
+<% end %>
+
 <% if can?(:delete, 'devices') %>
 <div><%= link_to 'Delete', nil, method: :delete, data: {confirm: 'Are you sure you want to delete this device?'} %></div>
 <% end %>
+</p>
 
 <div id="pending">
   <h>Pending tasks</h>

--- a/app/views/devices/show.html.erb
+++ b/app/views/devices/show.html.erb
@@ -151,7 +151,6 @@ $(function() {
 </div>
 <% end %>
 <% if can?(:create, 'files') %>
-
 <div><%= link_to 'Add Firmware', {controller: 'files', action: 'new', params: {oui: @device['summary.oui'].html_safe, product_class: @device['summary.productClass'].html_safe, version: @device['summary.softwareVersion']['_value'].html_safe }}  %></div>
 <% end %>
 

--- a/app/views/files/_form.html.erb
+++ b/app/views/files/_form.html.erb
@@ -5,15 +5,15 @@
 </div>
 <div>
   <%= label_tag('oui', 'OUI:') %>
-  <%= text_field_tag 'oui' %>
+  <%= text_field_tag 'oui', params[:oui] %>
 </div>
 <div>
   <%= label_tag('product_class', 'Product class:') %>
-  <%= text_field_tag 'product_class' %>
+  <%= text_field_tag 'product_class', params[:product_class] %>
 </div>
 <div>
   <%= label_tag('version', 'Version:') %>
-  <%= text_field_tag 'version' %>
+  <%= text_field_tag 'version', params[:version] %>
 </div>
 <div>
   <%= label_tag('file', 'File:') %>


### PR DESCRIPTION
Add a helper on the device page to populate the form fields on the file upload page with the current CPE info page (oui, product class and version).

Also fixes a misspelling and a html tag that only gets closed if the user has the can?(:update, 'devices/download') permission.