### PR TITLE
Allow connections to the NBI using HTTPS

### DIFF
--- a/app/controllers/faults_controller.rb
+++ b/app/controllers/faults_controller.rb
@@ -1,6 +1,7 @@
 class FaultsController < ApplicationController
   require 'net/http'
   require 'json'
+  require 'util'
 
   def find_faults(query, skip = 0, limit = Rails.configuration.page_size)
     q = {
@@ -8,7 +9,7 @@ class FaultsController < ApplicationController
       'skip' => skip,
       'limit' => limit
     }
-    http = Net::HTTP.new(Rails.configuration.genieacs_api_host, Rails.configuration.genieacs_api_port)
+    http = create_api_conn()
     res = http.get("/tasks/?#{q.to_query}")
     @total = res['Total'].to_i
     return ActiveSupport::JSON.decode(res.body)
@@ -34,7 +35,7 @@ class FaultsController < ApplicationController
   # POST /faults/:id/retry
   def retry
     can?(:update, 'tasks/retry') do
-      http = Net::HTTP.new(Rails.configuration.genieacs_api_host, Rails.configuration.genieacs_api_port)
+      http = create_api_conn()
       res = http.post("/tasks/#{params[:id]}/retry", nil)
       if res.code == '200'
         flash[:success] = 'Task updated'
@@ -50,7 +51,7 @@ class FaultsController < ApplicationController
   # DELETE /faults/1.json
   def destroy
     can?(:delete, 'tasks') do
-      http = Net::HTTP.new(Rails.configuration.genieacs_api_host, Rails.configuration.genieacs_api_port)
+      http = create_api_conn()
       res = http.delete("/tasks/#{params[:id]}", nil)
       if res.code == '200'
         flash[:success] = 'Faulty task deleted'

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,9 +1,11 @@
 class HomeController < ApplicationController
+  require 'util'
+
   def index
     can?(:read, 'home') do
       @graphs = Rails.cache.fetch('graphs', :expires_in => 60.seconds) do
         require 'net/http'
-        http = Net::HTTP.new(Rails.configuration.genieacs_api_host, Rails.configuration.genieacs_api_port)
+        http = create_api_conn()
 
         graphs = ActiveSupport::JSON.decode(ERB.new(File.read('config/graphs.json.erb')).result)
         for group_name, group_graphs in graphs

--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -1,12 +1,13 @@
 class ObjectsController < ApplicationController
   require 'net/http'
   require 'json'
+  require 'util'
 
   def get_object(id)
     query = {
       'query' => ActiveSupport::JSON.encode({'_id' => id}),
     }
-    http = Net::HTTP.new(Rails.configuration.genieacs_api_host, Rails.configuration.genieacs_api_port)
+    http = create_api_conn()
     res = http.get("/objects/?#{query.to_query}")
     return ActiveSupport::JSON.decode(res.body)[0]
   end
@@ -17,7 +18,7 @@ class ObjectsController < ApplicationController
       'skip' => skip,
       'limit' => limit
     }
-    http = Net::HTTP.new(Rails.configuration.genieacs_api_host, Rails.configuration.genieacs_api_port)
+    http = create_api_conn()
     res = http.get("/objects/?#{q.to_query}")
     @total = res['Total'].to_i
     return ActiveSupport::JSON.decode(res.body)
@@ -66,7 +67,7 @@ class ObjectsController < ApplicationController
     can?(:update, 'objects') do
       object = ActiveSupport::JSON.decode(params['parameters'])
 
-      http = Net::HTTP.new(Rails.configuration.genieacs_api_host, Rails.configuration.genieacs_api_port)
+      http = create_api_conn()
       res = http.put("/objects/#{URI.escape(params['name'].strip)}", ActiveSupport::JSON.encode(object))
       if res.code == '200'
         flash[:success] = 'Object saved'
@@ -82,7 +83,7 @@ class ObjectsController < ApplicationController
   # DELETE /objects/1.json
   def destroy
     can?(:delete, 'objects') do
-      http = Net::HTTP.new(Rails.configuration.genieacs_api_host, Rails.configuration.genieacs_api_port)
+      http = create_api_conn()
       res = http.delete("/objects/#{URI.escape(params[:id])}", nil)
       if res.code == '200'
         flash[:success] = 'Object deleted'

--- a/app/controllers/presets_controller.rb
+++ b/app/controllers/presets_controller.rb
@@ -1,12 +1,13 @@
 class PresetsController < ApplicationController
   require 'net/http'
   require 'json'
+  require 'util'
 
   def get_preset(id)
     query = {
       'query' => ActiveSupport::JSON.encode({'_id' => id}),
     }
-    http = Net::HTTP.new(Rails.configuration.genieacs_api_host, Rails.configuration.genieacs_api_port)
+    http = create_api_conn()
     res = http.get("/presets/?#{query.to_query}")
     return ActiveSupport::JSON.decode(res.body)[0]
   end
@@ -17,7 +18,7 @@ class PresetsController < ApplicationController
       'skip' => skip,
       'limit' => limit
     }
-    http = Net::HTTP.new(Rails.configuration.genieacs_api_host, Rails.configuration.genieacs_api_port)
+    http = create_api_conn()
     res = http.get("/presets/?#{q.to_query}")
     @total = res['Total'].to_i
     return ActiveSupport::JSON.decode(res.body)
@@ -69,7 +70,7 @@ class PresetsController < ApplicationController
       preset['precondition'] = params['query']
       preset['configurations'] = ActiveSupport::JSON.decode(params['configurations'])
 
-      http = Net::HTTP.new(Rails.configuration.genieacs_api_host, Rails.configuration.genieacs_api_port)
+      http = create_api_conn()
       res = http.put("/presets/#{URI.escape(params['name'].strip)}", ActiveSupport::JSON.encode(preset))
       if res.code == '200'
         flash[:success] = 'Preset saved'
@@ -85,7 +86,7 @@ class PresetsController < ApplicationController
   # DELETE /presets/1.json
   def destroy
     can?(:delete, 'presets') do
-      http = Net::HTTP.new(Rails.configuration.genieacs_api_host, Rails.configuration.genieacs_api_port)
+      http = create_api_conn()
       res = http.delete("/presets/#{URI.escape(params[:id])}", nil)
       if res.code == '200'
         flash[:success] = 'Preset deleted'

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -30,5 +30,5 @@ GenieacsGui::Application.configure do
   # GenieACS API
   config.genieacs_api_host = 'localhost'
   config.genieacs_api_port = 7557
-  config.genieacs_api_scheme = 'http'
+  config.genieacs_api_use_ssl = false
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -30,4 +30,5 @@ GenieacsGui::Application.configure do
   # GenieACS API
   config.genieacs_api_host = 'localhost'
   config.genieacs_api_port = 7557
+  config.genieacs_api_scheme = 'http'
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -81,4 +81,5 @@ GenieacsGui::Application.configure do
   # GenieACS API
   config.genieacs_api_host = 'localhost'
   config.genieacs_api_port = 7557
+  config.genieacs_api_scheme = 'http'
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -81,5 +81,5 @@ GenieacsGui::Application.configure do
   # GenieACS API
   config.genieacs_api_host = 'localhost'
   config.genieacs_api_port = 7557
-  config.genieacs_api_scheme = 'http'
+  config.genieacs_api_use_ssl = false
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -37,4 +37,5 @@ GenieacsGui::Application.configure do
   # GenieACS API
   config.genieacs_api_host = 'localhost'
   config.genieacs_api_port = 7557
+  config.genieacs_api_use_ssl = false
 end

--- a/lib/util.rb
+++ b/lib/util.rb
@@ -1,0 +1,8 @@
+
+def create_api_conn
+  http = Net::HTTP.new(Rails.configuration.genieacs_api_host, Rails.configuration.genieacs_api_port)
+  http.use_ssl = Rails.configuration.genieacs_api_scheme == 'https'
+  #http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+
+  return http
+end

--- a/lib/util.rb
+++ b/lib/util.rb
@@ -1,7 +1,7 @@
 
 def create_api_conn
   http = Net::HTTP.new(Rails.configuration.genieacs_api_host, Rails.configuration.genieacs_api_port)
-  http.use_ssl = Rails.configuration.genieacs_api_scheme == 'https'
+  http.use_ssl = Rails.configuration.genieacs_api_use_ssl
   #http.verify_mode = OpenSSL::SSL::VERIFY_NONE
 
   return http


### PR DESCRIPTION
The work for the NBI to support SSL has already been done, but the work on the GUI side didn't appear to be done. In starting this task, this line was in 30+ spots:

        http = Net::HTTP.new(Rails.configuration.genieacs_api_host, Rails.configuration.genieacs_api_port)

Because the change to use_ssl was going to require touching a lot of lines, I decided to abstract the creating of the connection to the NBI away into another file.

Please let me know if any changes need to be made.