### PR TITLE
Show the actual time of the last inform in a tooltip

### DIFF
--- a/app/views/devices/index.html.erb
+++ b/app/views/devices/index.html.erb
@@ -43,7 +43,7 @@ filters = {
     <% end %>
     <td>
       <% cls = 'status-green' if (@now - device['summary.lastInform'].to_time) < 300 %>
-      <span class="<%= cls %>"><%= distance_of_time_in_words(@now, device['summary.lastInform'], include_seconds: true) %> ago</span>
+      <span class="<%= cls %>" title="<%=device['summary.lastInform'].to_time.in_time_zone%>"><%= distance_of_time_in_words(@now, device['summary.lastInform'], include_seconds: true) %> ago</span>
     </td>
     <td class="action"><%= link_to 'Show', "/devices/#{u(device['_id'])}" %></td>
   </tr>

--- a/app/views/devices/show.html.erb
+++ b/app/views/devices/show.html.erb
@@ -36,7 +36,7 @@ $(function() {
 <p>
   <b>Last inform:</b>
   <% cls = 'status-green' if (@now - @device['summary.lastInform'].to_time) < 60 %>
-  <span class="<%= cls %>"><%= distance_of_time_in_words(@now, @device['summary.lastInform'], include_seconds: true) %> ago</span>
+  <span class="<%= cls %>" title="<%=@device['summary.lastInform'].to_time.in_time_zone%>"><%= distance_of_time_in_words(@now, @device['summary.lastInform'], include_seconds: true) %> ago</span>
   <% if can?(:read, 'devices/refresh_summary') %>
   &mdash;
   <a href="#" class="action" onclick="refreshSummary(); return false;">Refresh</a>,


### PR DESCRIPTION
Simple change, when hovering over the last inform value, you can now see the exact date and time in a tooltip