### PR TITLE
Add nil check on v3

### DIFF
--- a/app/views/devices/_object_table.html.erb
+++ b/app/views/devices/_object_table.html.erb
@@ -23,7 +23,7 @@
     <td class="action">
       <%= param_value("#{params['_object']}.#{k}.#{v2}", @device) rescue '' %>
       <% v3 = get_param(v2, v) %>
-      <% if v3['_writable'] %>
+      <% if v3 && v3['_writable'] %>
       <% options = Rails.configuration.parameters_edit["#{params['_object']}.#{k}.#{v2}".gsub(/\.\d+\./, '..')] %>
       <a href="#" onclick='editParam("<%= "#{params['_object']}.#{k}.#{v2}" %>", "<%= v3['_type'] %>", "<%= v3['_value'] %>", <%= options.to_json.html_safe %>);return false;'>Edit</a>
       <% end %>


### PR DESCRIPTION
Stack trace for what led to this change.  Not sure if there's a problem with my end device (I only had this problem after a software upgrade) but adding the nil check seemed to mask the root issue.
```
F, [2015-08-17T18:17:49.829884 #17904] FATAL -- :
ActionView::Template::Error (undefined method `[]' for nil:NilClass):
    23:     <td class="action">
    24:       <%= param_value("#{params['_object']}.#{k}.#{v2}", @device) rescue '' %>
    25:       <% v3 = get_param(v2, v) %>
    26:       <% if v3['_writable'] %>
    27:       <% options = Rails.configuration.parameters_edit["#{params['_object']}.#{k}.#{v2}".gsub(/\.\d+\./, '..')] %>
    28:       <a href="#" onclick='editParam("<%= "#{params['_object']}.#{k}.#{v2}" %>", "<%= v3['_type'] %>", "<%= v3['_value'] %>", <%= options.to_json.html_safe %>);return false;'>Edit</a>
    29:       <% end %>
  app/views/devices/_object_table.html.erb:26:in `block (2 levels) in _app_views_devices__object_table_html_erb__2413244525344402706_70221049300920'
  app/views/devices/_object_table.html.erb:14:in `each'
  app/views/devices/_object_table.html.erb:14:in `block in _app_views_devices__object_table_html_erb__2413244525344402706_70221049300920'
  app/views/devices/_object_table.html.erb:11:in `each'
  app/views/devices/_object_table.html.erb:11:in `_app_views_devices__object_table_html_erb__2413244525344402706_70221049300920'
  app/views/devices/show.html.erb:85:in `block in _app_views_devices_show_html_erb___361319597042453863_34177900'
  app/views/devices/show.html.erb:83:in `each'
  app/views/devices/show.html.erb:83:in `_app_views_devices_show_html_erb___361319597042453863_34177900'
  app/controllers/devices_controller.rb:107:in `block in show'
  app/controllers/application_controller.rb:40:in `can?'
  app/controllers/devices_controller.rb:101:in `show'
```