### PR TITLE
Fix users and roles index query for pagination

### DIFF
--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -2,7 +2,9 @@ class RolesController < ApplicationController
   
   def index
     can?(:read, 'roles') do
-      @roles = Role.all
+      off = params.include?(:page) ? (Integer(params[:page]) - 1) * Rails.configuration.page_size : 0
+      lim = Rails.configuration.page_size
+      @roles = Role.limit(lim).offset(off)
       @total = Role.count
     end
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,7 +2,9 @@ class UsersController < ApplicationController
   
   def index
     can?(:read, 'users') do
-      @users = User.all
+      off = params.include?(:page) ? (Integer(params[:page]) - 1) * Rails.configuration.page_size : 0
+      lim = Rails.configuration.page_size
+      @users = User.limit(lim).offset(off)
       @total = User.count
     end
   end


### PR DESCRIPTION
I forgot to limit the queries to fetch users/roles for the index pages to the range for the current page. This commit fixes that.