### PR TITLE
Add session expiry time to 30min

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,5 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_genieacs-gui_session'
+Rails.application.config.session_store :cookie_store,
+  key: '_genieacs-gui_session',
+  expire_after: 30.minutes


### PR DESCRIPTION
In order to accomplish first question of Issue talked [here](https://github.com/zaidka/genieacs/issues/121) (I can't refer because the issue was posted in the "genieacs" repo, not in "genieacs-gui")

I think it would be great to put it by default to 30min, or whatever you consider, @zaidka 

I've tried the changes in my own local copy and it works. If you don't perform any action in 30 min, then it logs off.
