### PR TITLE
Use db as default authentication method

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -16,8 +16,8 @@ module GenieacsGui
 
     # Set preferred authentication method to use
     # :yml = use roles from roles.yml and users from users.yml
-    config.auth_method = :yml
+    #config.auth_method = :yml
     # :db = use roles and users stored in the database
-    #config.auth_method = :db
+    config.auth_method = :db
   end
 end


### PR DESCRIPTION
I would like make databased authentication the default method. In my experience most users want to use this method.

I recommend to then extend the install instructions on https://genieacs.com/ by adding the following text after "bundle":

The database needs to be initialized by running:
bin/rake db:migrate RAILS_ENV=development
bin/rake db:seed