### PR TITLE
Extend length of command field to be able to take a custom command with several arguments

### DIFF
--- a/app/assets/stylesheets/presets.css.scss
+++ b/app/assets/stylesheets/presets.css.scss
@@ -20,4 +20,7 @@
   input[_name=args] {
     width: 400px;
   }
+  input[_name=command] {
+    width: 400px;
+  }
 }


### PR DESCRIPTION
If you use a custom command which takes several arguments then the field for the command is too short because you have to provide:

<filename> <functionname> <argument 1> <argument 2> <argument 3>

This commit increases the length of the command field.