### PR TITLE
Fix Edit and Destroy links for objects, provisions and virtual parameters

### DIFF
--- a/app/views/objects/index.html.erb
+++ b/app/views/objects/index.html.erb
@@ -16,8 +16,8 @@ content_for :title do 'Object List' end
 <% @objects.each do |object| %>
   <tr>
     <td><%= object['_id'] %></td>
-    <td class="action"><%= link_to 'Edit', "/objects/#{object['_id']}/edit" if can?(:update, 'objects') %></td>
-    <td class="action"><%= link_to 'Destroy', "/objects/#{object['_id']}", method: :delete, data: { confirm: 'Are you sure?' } if can?(:delete, 'objects') %></td>
+    <td class="action"><%= link_to 'Edit', {controller: 'objects', action: 'edit', id: object['_id']} if can?(:update, 'objects') %></td>
+    <td class="action"><%= link_to 'Destroy', {controller: 'objects', action: 'destroy', id: object['_id']}, method: :delete, data: { confirm: 'Are you sure?' } if can?(:delete, 'objects') %></td>
   </tr>
 <% end %>
 </table>

--- a/app/views/provisions/index.html.erb
+++ b/app/views/provisions/index.html.erb
@@ -16,8 +16,8 @@ content_for :title do 'Provision List' end
 <% @provisions.each do |provision| %>
   <tr>
     <td><%= provision['_id'] %></td>
-    <td class="action"><%= link_to 'Edit', "/provisions/#{provision['_id']}/edit" if can?(:update, 'provisions') %></td>
-    <td class="action"><%= link_to 'Destroy', "/provisions/#{provision['_id']}", method: :delete, data: { confirm: 'Are you sure?' } if can?(:delete, 'provisions') %></td>
+    <td class="action"><%= link_to 'Edit', {controller: 'provisions', action: 'edit', id: provision['_id']} if can?(:update, 'provisions') %></td>
+    <td class="action"><%= link_to 'Destroy', {controller: 'provisions', action: 'destroy', id: provision['_id']}, method: :delete, data: { confirm: 'Are you sure?' } if can?(:delete, 'provisions') %></td>
   </tr>
 <% end %>
 </table>

--- a/app/views/virtual_parameters/index.html.erb
+++ b/app/views/virtual_parameters/index.html.erb
@@ -16,8 +16,8 @@ content_for :title do 'Virtual Parameter List' end
 <% @virtual_parameters.each do |virtual_parameter| %>
   <tr>
     <td><%= virtual_parameter['_id'] %></td>
-    <td class="action"><%= link_to 'Edit', "/virtual_parameters/#{virtual_parameter['_id']}/edit" if can?(:update, 'virtual_parameters') %></td>
-    <td class="action"><%= link_to 'Destroy', "/virtual_parameters/#{virtual_parameter['_id']}", method: :delete, data: { confirm: 'Are you sure?' } if can?(:delete, 'virtual_parameters') %></td>
+    <td class="action"><%= link_to 'Edit', {controller: 'virtual_parameters', action: 'edit', id: virtual_parameter['_id']} if can?(:update, 'virtual_parameters') %></td>
+    <td class="action"><%= link_to 'Destroy', {controller: 'virtual_parameters', action: 'destroy', id: virtual_parameter['_id']}, method: :delete, data: { confirm: 'Are you sure?' } if can?(:delete, 'virtual_parameters') %></td>
   </tr>
 <% end %>
 </table>


### PR DESCRIPTION
The Edit and Destroy links for objects, provisions and virtual parameters are broken if the name of the entity contains characters which must be URL-encoded. This commit fixes the links by constructing them analog to the presets index view.