### PR TITLE
Add filters for presets

### DIFF
--- a/app/controllers/presets_controller.rb
+++ b/app/controllers/presets_controller.rb
@@ -33,7 +33,12 @@ class PresetsController < ApplicationController
     can?(:read, 'presets') do
       skip = params.include?(:page) ? (Integer(params[:page]) - 1) * Rails.configuration.page_size : nil
 
-      res = query_resource(create_api_conn(), 'presets', nil, nil, skip, Rails.configuration.page_size)
+      @query = {}
+      if params.has_key?('query')
+        @query = ActiveSupport::JSON.decode(URI.unescape(params['query']))
+      end
+
+      res = query_resource(create_api_conn(), 'presets', @query, nil, skip, Rails.configuration.page_size)
       @presets = res[:result]
       @total = res[:total]
 

--- a/app/views/presets/index.html.erb
+++ b/app/views/presets/index.html.erb
@@ -2,6 +2,27 @@
 content_for :title do 'Preset List' end
 %>
 <h1>Listing presets</h1>
+<script type="text/javascript">
+filters = {
+<% for k,v in Rails.configuration.preset_filters %>
+  <% for vv in v %>
+  '<%= vv %>' : '<%= if v.length == 1 then k else vv end %>',
+  <% end %>
+<% end %>
+}
+</script>
+<b>Filters</b>
+<form id="filters" onsubmit="updateFilters('filters');" >
+  <input type="hidden" name="query" value='<%= @query.to_json %>' />
+  <input type="hidden" name="sort" value="<%= params[:sort] %>" />
+  <div class="filters_container"></div>
+  <div class="filter_selection"></div>
+  <br/><br/>
+  <div>
+    <input type="submit" value="Filter" />
+    <%= link_to 'Clear', {} %>
+  </div>
+</form>
 
 <h2>Showing <%= @total %> presets</h2>
 
@@ -35,3 +56,9 @@ content_for :title do 'Preset List' end
 <br />
 
 <%= link_to 'New Preset', {:action => :new} if can?(:create, 'presets') %>
+
+<script type="text/javascript">
+$(function() {
+  initFilters('filters');
+});
+</script>

--- a/config/initializers/parameters.rb
+++ b/config/initializers/parameters.rb
@@ -28,6 +28,10 @@ end
 
 GenieacsGui::Application.config.device_filters.each {|k, v| v.uniq!}
 
+GenieacsGui::Application.config.preset_filters = {'Name' => ['_id'], 'Precondition' => ['precondition'],
+                                                  'Configurations - Set value' => ['configurations.value'],
+                                                  'Configurations - Provision name' => ['configurations.name']}
+
 module ParameterRenderers
   Dir['config/parameter_renderers/*.rb'].each {|file| load "./#{file}" }
 end


### PR DESCRIPTION
This commit adds filters to the presets index page (similar to the devices index page). Current filters include

* preset name
* precondition string
* value of Set configurations
* name of Provision configurations

This PR requires https://github.com/zaidka/genieacs/pull/277.